### PR TITLE
Update description for To-do Helpers

### DIFF
--- a/integrations.yml
+++ b/integrations.yml
@@ -264,8 +264,8 @@ integrations:
     image: extras/timely.png
     category: 2
   - title: 'To-do Helpers'
-    description: 'Create recurring to-dos in Basecamp, and auto-assign and auto-set due dates on your Basecamp to-dos'
-    url: 'https://app.todohelpers.com'
+    description: 'Create and share forms that submit directly to your Basecamp to-do lists. Auto-assign and auto-set due dates on your Basecamp to-dos.'
+    url: 'https://app.todohelpers.com' 
     image: extras/todohelpers.png
     category: 1
   - title: 'Timeshift Messenger'

--- a/integrations.yml
+++ b/integrations.yml
@@ -265,7 +265,7 @@ integrations:
     category: 2
   - title: 'To-do Helpers'
     description: 'Create and share forms that submit directly to your Basecamp to-do lists. Auto-assign and auto-set due dates on your Basecamp to-dos.'
-    url: 'https://app.todohelpers.com' 
+    url: 'https://app.todohelpers.com'
     image: extras/todohelpers.png
     category: 1
   - title: 'Timeshift Messenger'


### PR DESCRIPTION
This updates the description for To-do Helpers to reflect a new features we've added, the ability to create forms that submit directly to Basecamp to-do lists. 

Happy to provide any other info. Thank you!